### PR TITLE
bug- 0 width bar in reach

### DIFF
--- a/app/components/elements/ValueBar/index.jsx
+++ b/app/components/elements/ValueBar/index.jsx
@@ -17,9 +17,12 @@ class ValueBar extends React.Component {
     const value = this.props.value;
     const ranges = [0, 1000, 5000, 10000, 20000, 50000, 100000, 500000, 1000000, 10000000, 50000000];
     const widths = [16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176];
-
     const index = ranges.findIndex((r, i) => value > r && value <= ranges[i + 1]);
-    const widthValue = widths[index] || widths[widths.length - 1];
+
+    let widthValue = 0;
+
+    if (value !== 0) { widthValue = widthValue = widths[index] || widths[widths.length - 1] }
+
 
     let styles = {
       current: {


### PR DESCRIPTION
When participants are 0, the bar took all the width. 